### PR TITLE
Fix ValueError in get_gemini_response function

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,18 @@ genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
 def get_gemini_response(input, pdf_content, prompt):
     model = genai.GenerativeModel('gemini-pro-vision')
     response = model.generate_content([input, pdf_content[0], prompt])
-    return response.text
+    
+    # Check if the response is a single part
+    if len(response.parts) == 1:
+        return response.parts[0].text
+    else:
+        # If the response has multiple parts, we need to concatenate them
+        # or process them differently based on our use case
+        concatenated_text = ""
+        for part in response.parts:
+            concatenated_text += part.text
+        return concatenated_text
+
 
 def input_pdf_setup(uploaded_file):
     if uploaded_file is not None:


### PR DESCRIPTION
This pull request addresses an issue encountered in the get_gemini_response function, which resulted in a ValueError when attempting to access response.text for responses containing multiple parts. To resolve this issue, I have modified the function to handle responses with multiple parts appropriately.

Changes Made:

Updated the get_gemini_response function to check if the response contains multiple parts and concatenate the text from all parts when necessary.
Ensured that the function handles both simple text responses and responses with multiple parts, preventing the ValueError from occurring.
Testing:
I have tested the modified function locally with various inputs and confirmed that it functions as expected. The function now properly handles responses from the GEMINI AI model without raising any errors.

Additional Context:
This fix improves the reliability and robustness of the get_gemini_response function, ensuring that it can handle a wider range of response types from the GEMINI AI model. The changes made in this pull request should enhance the overall functionality and user experience of the application.